### PR TITLE
Add new test case for incorrect solutions

### DIFF
--- a/verification/tests.py
+++ b/verification/tests.py
@@ -19,6 +19,10 @@ TESTS = {
             "answer": False
         },
         {
+            "input": ["bar", "foo"],
+            "answer": True
+        },
+        {
             "input": ["", ""],
             "answer": True
         },


### PR DESCRIPTION
I have seen multiple solutions where players assume incorrectly, that multiple characters cannot be mapped to same character, even though this is clearly stated in the description of the task.

Example for an incorrect solution:
```python
def isometric_strings(str1: str, str2: str) -> bool:
    for x, y in zip(str1, str2):
        if str1.count(x) != str2.count(y):
            return False
    return True
```
The test case `isometric_strings("bar", "foo") == True` should be able to catch these solutions.