### PR TITLE
add ["bar", "foo"] test

### DIFF
--- a/verification/tests.py
+++ b/verification/tests.py
@@ -19,6 +19,10 @@ TESTS = {
             "answer": False
         },
         {
+            "input": ["bar", "foo"],
+            "answer": True
+        },
+        {
             "input": ["", ""],
             "answer": True
         },


### PR DESCRIPTION
"Two or more characters of one string can correspond to one character of another string, but not vice versa."
So ["bar", "foo"] should have answer: True

This is not covered by any basics or extra test before.